### PR TITLE
refactor: use discord.js WebhookClient over node-fetch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -261,6 +261,21 @@
 			"integrity": "sha512-r3fwVbVH+M8W0qYlBBZFsUwKe6NT5qvz+EmU7sr8VeN1cQ63z+3cfXyTo7WGGEMEgKiT0jboNAK3b1FZp8k9LQ==",
 			"dev": true
 		},
+		"@discordjs/collection": {
+			"version": "0.1.6",
+			"resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-0.1.6.tgz",
+			"integrity": "sha512-utRNxnd9kSS2qhyivo9lMlt5qgAUasH2gb7BEOn6p0efFh24gjGomHzWKMAPn2hEReOPQZCJaRKoURwRotKucQ=="
+		},
+		"@discordjs/form-data": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/@discordjs/form-data/-/form-data-3.0.1.tgz",
+			"integrity": "sha512-ZfFsbgEXW71Rw/6EtBdrP5VxBJy4dthyC0tpQKGKmYFImlmmrykO14Za+BiIVduwjte0jXEBlhSKf0MWbFp9Eg==",
+			"requires": {
+				"asynckit": "^0.4.0",
+				"combined-stream": "^1.0.8",
+				"mime-types": "^2.1.12"
+			}
+		},
 		"@eslint/eslintrc": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.1.3.tgz",
@@ -367,16 +382,6 @@
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.6.4.tgz",
 			"integrity": "sha512-Wk7nG1JSaMfMpoMJDKUsWYugliB2Vy55pdjLpmLixeyMi7HizW2I/9QoxsPCkXl3dO+ZOVqPumKaDUv5zJu2uQ==",
 			"dev": true
-		},
-		"@types/node-fetch": {
-			"version": "2.5.7",
-			"resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.7.tgz",
-			"integrity": "sha512-o2WVNf5UhWRkxlf6eq+jMZDu7kjgpgJfl4xVNlvryc95O/6F2ld8ztKX+qu+Rjyet93WAWm5LjeX9H5FGkODvw==",
-			"dev": true,
-			"requires": {
-				"@types/node": "*",
-				"form-data": "^3.0.0"
-			}
 		},
 		"@types/normalize-package-data": {
 			"version": "2.4.0",
@@ -486,6 +491,14 @@
 				"through": ">=2.2.7 <3"
 			}
 		},
+		"abort-controller": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+			"integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+			"requires": {
+				"event-target-shim": "^5.0.0"
+			}
+		},
 		"acorn": {
 			"version": "7.4.0",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.0.tgz",
@@ -589,8 +602,7 @@
 		"asynckit": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-			"dev": true
+			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
 		},
 		"balanced-match": {
 			"version": "1.0.0",
@@ -730,7 +742,6 @@
 			"version": "1.0.8",
 			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
 			"integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-			"dev": true,
 			"requires": {
 				"delayed-stream": "~1.0.0"
 			}
@@ -878,14 +889,34 @@
 		"delayed-stream": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-			"dev": true
+			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
 		},
 		"diff-sequences": {
 			"version": "25.2.6",
 			"resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-25.2.6.tgz",
 			"integrity": "sha512-Hq8o7+6GaZeoFjtpgvRBUknSXNeJiCx7V9Fr94ZMljNiCr9n9L8H8aJqgWOQiDDGdyn29fRNcDdRVJ5fdyihfg==",
 			"dev": true
+		},
+		"discord-api-types": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.2.0.tgz",
+			"integrity": "sha512-jBjhVMFCKzo2rVcoctFa+pyuvXAjcYmgpGDgdLBMkmvyViBmseajAZlQnQiq+qtPhw587CilQADccOXQFgrJTA==",
+			"dev": true
+		},
+		"discord.js": {
+			"version": "12.3.1",
+			"resolved": "https://registry.npmjs.org/discord.js/-/discord.js-12.3.1.tgz",
+			"integrity": "sha512-mSFyV/mbvzH12UXdS4zadmeUf8IMQOo/YdunubG1wWt1xjWvtaJz/s9CGsFD2B5pTw1W/LXxxUbrQjIZ/xlUdw==",
+			"requires": {
+				"@discordjs/collection": "^0.1.6",
+				"@discordjs/form-data": "^3.0.1",
+				"abort-controller": "^3.0.0",
+				"node-fetch": "^2.6.0",
+				"prism-media": "^1.2.2",
+				"setimmediate": "^1.0.5",
+				"tweetnacl": "^1.0.3",
+				"ws": "^7.3.1"
+			}
 		},
 		"doctrine": {
 			"version": "3.0.0",
@@ -1118,6 +1149,11 @@
 			"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
 			"dev": true
 		},
+		"event-target-shim": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+			"integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
+		},
 		"fast-deep-equal": {
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -1215,17 +1251,6 @@
 			"resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.2.tgz",
 			"integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==",
 			"dev": true
-		},
-		"form-data": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.0.tgz",
-			"integrity": "sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==",
-			"dev": true,
-			"requires": {
-				"asynckit": "^0.4.0",
-				"combined-stream": "^1.0.8",
-				"mime-types": "^2.1.12"
-			}
 		},
 		"fs-extra": {
 			"version": "8.1.0",
@@ -1843,14 +1868,12 @@
 		"mime-db": {
 			"version": "1.44.0",
 			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz",
-			"integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg==",
-			"dev": true
+			"integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg=="
 		},
 		"mime-types": {
 			"version": "2.1.27",
 			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.27.tgz",
 			"integrity": "sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==",
-			"dev": true,
 			"requires": {
 				"mime-db": "1.44.0"
 			}
@@ -2124,6 +2147,11 @@
 				"react-is": "^16.12.0"
 			}
 		},
+		"prism-media": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/prism-media/-/prism-media-1.2.2.tgz",
+			"integrity": "sha512-I+nkWY212lJ500jLe4tN9tWO7nRiBAVdMv76P9kffZjYhw20raMlW1HSSvS+MLXC9MmbNZCazMrAr+5jEEgTuw=="
+		},
 		"process-nextick-args": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
@@ -2339,6 +2367,11 @@
 			"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
 			"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
 			"dev": true
+		},
+		"setimmediate": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+			"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
 		},
 		"shebang-command": {
 			"version": "2.0.0",
@@ -2669,6 +2702,11 @@
 				"tslib": "^1.8.1"
 			}
 		},
+		"tweetnacl": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
+			"integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="
+		},
 		"type-check": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -2779,6 +2817,11 @@
 			"requires": {
 				"mkdirp": "^0.5.1"
 			}
+		},
+		"ws": {
+			"version": "7.3.1",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-7.3.1.tgz",
+			"integrity": "sha512-D3RuNkynyHmEJIpD2qrgVkc9DQ23OrN/moAwZX4L8DfvszsJxpjQuUq3LMx6HoYji9fbIOBY18XWBsAux1ZZUA=="
 		},
 		"xtend": {
 			"version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -30,16 +30,16 @@
 		"discordapp"
 	],
 	"dependencies": {
-		"node-fetch": "^2.6.1"
+		"discord.js": "^12.3.1"
 	},
 	"devDependencies": {
 		"@commitlint/cli": "^9.1.2",
 		"@commitlint/config-angular": "^9.1.2",
 		"@types/jest": "^26.0.10",
 		"@types/node": "^14.6.4",
-		"@types/node-fetch": "^2.5.7",
 		"@typescript-eslint/eslint-plugin": "^3.10.1",
 		"@typescript-eslint/parser": "^3.10.1",
+		"discord-api-types": "^0.2.0",
 		"eslint": "^7.7.0",
 		"eslint-config-marine": "^7.2.0",
 		"eslint-config-prettier": "^6.11.0",

--- a/resources/RESOURCES.md
+++ b/resources/RESOURCES.md
@@ -91,4 +91,4 @@ _ _
 • [Google Cloud](https://cloud.google.com/free) free tier
 _ _
 
-⬆ [jump to the top](https://canary.discordapp.com/channels/222078108977594368/729580210634358804/0)
+⬆ [jump to the top](%JUMP_TO_TOP%)

--- a/resources/RESOURCES.md
+++ b/resources/RESOURCES.md
@@ -28,7 +28,7 @@ _ _
 **Regular expressions:**
 Trying to get some content out of a string but it's too complicated for slicing and dicing? Regular Expressions might be what you need:
 • [Regex Guide](https://blog.bitsrc.io/a-beginners-guide-to-regular-expressions-regex-in-javascript-9c58feb27eb4)
-• Online Tester/Debugger:  [regex101](https://regex101.com/) | [regexr](http://regexr.com/) | [debuggex](https://www.debuggex.com/)
+• Online Tester/Debugger: [regex101](https://regex101.com/) | [regexr](http://regexr.com/) | [debuggex](https://www.debuggex.com/)
 • Interactive Guide: [regexone](https://regexone.com/)
 _ _
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -73,6 +73,7 @@ async function main(): Promise<void> {
 			})) as unknown) as RESTPostAPIChannelMessageResult;
 			if (!firstMessage) firstMessage = response;
 		}
+		hook.destroy();
 	}
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import { readFileSync, readdirSync } from 'fs';
 import { join } from 'path';
 import { WebhookClient } from 'discord.js';
-import { RESTPostAPIChannelMessageResult } from 'discord-api-types';
+import { RESTPostAPIChannelMessageResult } from 'discord-api-types/v6';
 
 const jumpRegex = /%JUMP_TO_TOP%/gm;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,13 +1,14 @@
 import { readFileSync, readdirSync } from 'fs';
 import { join } from 'path';
-import fetch from 'node-fetch';
-import { promisify } from 'util';
+import { WebhookClient } from 'discord.js';
+import { RESTPostAPIChannelMessageResult } from 'discord-api-types';
+
+const jumpRegex = /%JUMP_TO_TOP%/gm;
 
 const linkEscapeRegex = /\[(.+?)\]\((.+?)\)/gm;
 const linkEscapeReplacer = (_: any, p1: string, p2: string): string => {
 	return `[${p1}](<${p2}>)`;
 };
-const wait = promisify(setTimeout);
 
 const replacePatterns = {
 	'%RULES_CHANNEL%': '<#222109930545610754>',
@@ -45,7 +46,8 @@ async function main(): Promise<void> {
 	for (const channel of channels) {
 		console.log(`[STARTING] Deploying ${channel}`);
 
-		const hook = process.env[channel]!;
+		const [hookID, hookToken] = process.env[channel]!.split('/').slice(-2);
+		const hook = new WebhookClient(hookID, hookToken);
 		const fileName = `${channel}.md`;
 
 		const raw = readFileSync(join(__dirname, '..', 'resources', fileName)).toString();
@@ -56,24 +58,20 @@ async function main(): Promise<void> {
 		}, r1);
 		const parts = r2.split('\n\n');
 
-		for (const part of parts) {
-			const body = {
-				avatar_url: process.env.WEBHOOK_AVATAR,
-				username: process.env.WEBHOOK_NAME,
-				content: part,
-			};
-
-			const res = await fetch(hook, {
-				method: 'post',
-				body: JSON.stringify(body),
-				headers: { 'Content-Type': 'application/json' },
-			});
-
-			if (res.status !== 204) {
-				console.error(await res.json());
-				throw new Error(`[API] ${res.status}: ${res.statusText}`);
+		let firstMessage: RESTPostAPIChannelMessageResult | null = null;
+		for (let part of parts) {
+			if (firstMessage) {
+				part = part.replace(
+					jumpRegex,
+					`https://discord.com/channels/222078108977594368/${firstMessage.channel_id}/${firstMessage.id}`,
+				);
 			}
-			await wait(1000);
+			// A raw API response is returned here, not a Message object as the typings indicate
+			const response = ((await hook.send(part, {
+				avatarURL: process.env.WEBHOOK_AVATAR,
+				username: process.env.WEBHOOK_NAME,
+			})) as unknown) as RESTPostAPIChannelMessageResult;
+			if (!firstMessage) firstMessage = response;
 		}
 	}
 }


### PR DESCRIPTION
This PR removes the use of `node-fetch` and replaces it with the discord.js `WebhookClient`, to handle any ratelimits that may be encountered, it also adds a new replacer to dynamically get the jump URL required, however it wasn't added to the `replacePatterns` as its implementation needed to be different

ignore the test commits; the workflow wasn't registering