### PR TITLE
fix(*): re-introduce  forced wait

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import { readFileSync, readdirSync } from 'fs';
 import { join } from 'path';
 import { WebhookClient } from 'discord.js';
 import { RESTPostAPIChannelMessageResult } from 'discord-api-types/v6';
+import { promisify } from 'util';
 
 const jumpRegex = /%JUMP_TO_TOP%/gm;
 
@@ -19,6 +20,8 @@ const replacePatterns = {
 function resolveIdentifier(channelName: string): string {
 	return channelName.toUpperCase().replace(/-/gm, '_');
 }
+
+const wait = promisify(setTimeout);
 
 async function main(): Promise<void> {
 	const deployChannelString = process.env.DEPLOY_CHANNELS;
@@ -72,6 +75,8 @@ async function main(): Promise<void> {
 				username: process.env.WEBHOOK_NAME,
 			})) as unknown) as RESTPostAPIChannelMessageResult;
 			if (!firstMessage) firstMessage = response;
+
+			await wait(1000);
 		}
 		hook.destroy();
 	}


### PR DESCRIPTION
Re-introduces the removed (in #4) forced timeout in between send calls.  Execution on the server has shown that https://github.com/discordjs/resource-webhooks/pull/4#discussion_r487163250 is not enough to prevent race conditions from sending the hooks in the wrong order.

![image](https://user-images.githubusercontent.com/26532370/93364979-81129080-f849-11ea-876c-8d3f4c084d9d.png)
