### PR TITLE
chore(resources#popmods): replace moment with luxon

### DIFF
--- a/resources/RESOURCES.md
+++ b/resources/RESOURCES.md
@@ -45,7 +45,7 @@ _ _
 **Popular modules:**
 • [Canvas](https://www.npmjs.com/package/canvas) (image processing)
 • [Jimp](https://www.npmjs.com/package/jimp) (image processing)
-• [Moment](https://www.npmjs.com/package/moment) (date parsing)
+• [Luxon (from the creators of Moment)](https://www.npmjs.com/package/luxon) (date parsing)
 • [DateFNS](https://www.npmjs.com/package/date-fns) (date parsing)
 • [ms](https://www.npmjs.com/package/ms) (duration parsing)
 • [Sqlite](https://www.npmjs.com/package/sqlite) (single file database)

--- a/resources/RESOURCES.md
+++ b/resources/RESOURCES.md
@@ -45,7 +45,7 @@ _ _
 **Popular modules:**
 • [Canvas](https://www.npmjs.com/package/canvas) (image processing)
 • [Jimp](https://www.npmjs.com/package/jimp) (image processing)
-• [Luxon (from the creators of Moment)](https://www.npmjs.com/package/luxon) (date parsing)
+• [Luxon](https://www.npmjs.com/package/luxon) (date parsing)
 • [DateFNS](https://www.npmjs.com/package/date-fns) (date parsing)
 • [ms](https://www.npmjs.com/package/ms) (duration parsing)
 • [Sqlite](https://www.npmjs.com/package/sqlite) (single file database)


### PR DESCRIPTION
This PR replaces moment with luxon.

Why? https://momentjs.com/docs/#/-project-status/
