### PR TITLE
feat: remove invite in rule 8

### DIFF
--- a/resources/RULES.md
+++ b/resources/RULES.md
@@ -23,4 +23,4 @@ _ _
 **7.** If your username can't be easily mentioned, please set your nickname to something mentionable. For example, "ᐃᑦᑎᓂᖅᓯᐅᑐᖅ ᑕᖅᓴᖅ" isn't particularly useful.
 
 _ _
-**8.** No political / controversial content on this server. If you wish to discuss those topics, please find another place.
+**8.** No controversial content, including politics and religion, is allowed.

--- a/resources/RULES.md
+++ b/resources/RULES.md
@@ -23,4 +23,4 @@ _ _
 **7.** If your username can't be easily mentioned, please set your nickname to something mentionable. For example, "ᐃᑦᑎᓂᖅᓯᐅᑐᖅ ᑕᖅᓴᖅ" isn't particularly useful.
 
 _ _
-**8.** No political / controversial content on this server. If you wish to discuss those head over to: https://discord.gg/q4KdJFP
+**8.** No political / controversial content on this server. If you wish to discuss those topics, please find another place.

--- a/resources/RULES.md
+++ b/resources/RULES.md
@@ -23,4 +23,4 @@ _ _
 **7.** If your username can't be easily mentioned, please set your nickname to something mentionable. For example, "ᐃᑦᑎᓂᖅᓯᐅᑐᖅ ᑕᖅᓴᖅ" isn't particularly useful.
 
 _ _
-**8.** No controversial content, including politics and religion, is allowed.
+**8.** No controversial content is allowed, including politics and religion.


### PR DESCRIPTION
No other rule has an invite link in it, there's no reason to include an invite link to a server that discord.js has no affiliation with and no other relation to.  The embed adds clutter to the rules and is generally inconsistent with the rest of the rules' style.