### PR TITLE
chore: change package.json's license to match LICENSE

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
 	"contributors": [
 		"Crawl <icrawltogo@gmail.com>"
 	],
-	"license": "Apache-2.0",
+	"license": "MIT",
 	"private": true,
 	"scripts": {
 		"build": "rimraf dist && tsc",


### PR DESCRIPTION
The repository's license is [MIT](https://github.com/discordjs/resource-webhooks/blob/main/LICENSE) while the package.json's license was set to APACHE 2.0. This Pull Request changes package.json's license to MIT so it matches the LICENSE file.