### PR TITLE
chore: update links

### DIFF
--- a/resources/RESOURCES.md
+++ b/resources/RESOURCES.md
@@ -3,10 +3,10 @@ https://discord.gg/djs
 
 _ _
 **Main discord.js resources:**
-• [Documentation](https://discord.js.org/#/docs/discord.js/stable/general/welcome)
+• [Documentation](https://discord.js.org/#/docs/discord.js/main/general/welcome)
 • [GitHub](https://github.com/discordjs/discord.js)
 • [Guide](https://discordjs.guide/)
-• [Update to version 13](https://discordjs.guide/additional-info/changes-in-v13.html)
+• [Update to version 14](https://discordjs.guide/additional-info/changes-in-v14.html)
 • [Discord Developer Documentation](https://discord.com/developers/docs) (needed permissions etc.)
 _ _
 **Learning JavaScript and node.js:**


### PR DESCRIPTION
- Update the docs link to point to main, as the stable tag is broken.
- Update the update guide link to v14.