### PR TITLE
fix: Address deleted regex guide

### DIFF
--- a/resources/RESOURCES.md
+++ b/resources/RESOURCES.md
@@ -23,7 +23,7 @@ see %USEFUL_SERVERS_CHANNEL% for invites to general JavaScript and programming s
 _ _
 ### Regular expressions:
 Trying to get some content out of a string but it's too complicated for slicing and dicing? Regular Expressions might be what you need:
-- [Regex Guide](https://blog.bitsrc.io/a-beginners-guide-to-regular-expressions-regex-in-javascript-9c58feb27eb4)
+- [Regex Guide](https://builtin.com/software-engineering-perspectives/javascript-regex)
 - Online Tester/Debugger: [regex101](https://regex101.com/) | [regexr](http://regexr.com/) | [debuggex](https://www.debuggex.com/)
 - Interactive Guide: [regexone](https://regexone.com/)
 _ _


### PR DESCRIPTION
<img width="483" alt="image" src="https://github.com/user-attachments/assets/d9d1e7bd-8a75-49e2-94f3-1e1793d82268" />

Seems https://builtin.com/software-engineering-perspectives/javascript-regex is the replacement.